### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,4 @@
 AllCops:
   Exclude:
     - 'Dangerfile'
+    - 'vendor/**/*'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,24 +15,24 @@ This cookbook now targets the resource-oriented API only and is validated agains
 
 ## Supported platforms
 
-- Debian 12: `packages.debian.org` publishes `cgroup-tools`, `libcgroup2`, and `libpam-cgroup` for Bookworm, and this repository now runs Kitchen coverage for Debian 12.
-- Ubuntu 24.04: `packages.ubuntu.com` lists `libpam-cgroup` in Noble's `admin` section, confirming the libcgroup userspace packages are still published for the current LTS.
+* Debian 12: `packages.debian.org` publishes `cgroup-tools`, `libcgroup2`, and `libpam-cgroup` for Bookworm, and this repository now runs Kitchen coverage for Debian 12.
+* Ubuntu 24.04: `packages.ubuntu.com` lists `libpam-cgroup` in Noble's `admin` section, confirming the libcgroup userspace packages are still published for the current LTS.
 
 ## Researched but not supported
 
-- Amazon Linux 2023: AWS documents `libcgroup-tools` on AL2023, but the same documentation states AL2023 uses cgroup v2 and recommends `systemd` resource control instead. This cookbook still renders classic `cgconfig.conf` and `cgrules.conf` files, so AL2023 is documented as a limitation rather than an advertised target.
-- openSUSE Leap: the modern `software.opensuse.org` results for related cgroup packages are either absent or community/experimental, so this cookbook does not claim support.
-- RHEL-family clones: the repository no longer advertises CentOS or clone support without current package and runtime validation.
-- Dokken / cgroup-v2 containers: a direct `kitchen converge` on Debian 12 and Ubuntu 24.04 fails when `cgconfigparser` attempts to mount controller hierarchies from `cgconfig.conf` and receives `Operation not permitted`. The Kitchen suites therefore run with `manage_runtime false`, which verifies package installation, config generation, and systemd unit creation without attempting to start the libcgroup daemons in a cgroup-v2 container.
+* Amazon Linux 2023: AWS documents `libcgroup-tools` on AL2023, but the same documentation states AL2023 uses cgroup v2 and recommends `systemd` resource control instead. This cookbook still renders classic `cgconfig.conf` and `cgrules.conf` files, so AL2023 is documented as a limitation rather than an advertised target.
+* openSUSE Leap: the modern `software.opensuse.org` results for related cgroup packages are either absent or community/experimental, so this cookbook does not claim support.
+* RHEL-family clones: the repository no longer advertises CentOS or clone support without current package and runtime validation.
+* Dokken / cgroup-v2 containers: a direct `kitchen converge` on Debian 12 and Ubuntu 24.04 fails when `cgconfigparser` attempts to mount controller hierarchies from `cgconfig.conf` and receives `Operation not permitted`. The Kitchen suites therefore run with `manage_runtime false`, which verifies package installation, config generation, and systemd unit creation without attempting to start the libcgroup daemons in a cgroup-v2 container.
 
 ## Architecture notes
 
-- Debian and Ubuntu publish the libcgroup packages for multiple architectures through their normal package repositories.
-- This cookbook does not attempt source builds or vendor repositories; it relies on distro-packaged libcgroup utilities only.
+* Debian and Ubuntu publish the libcgroup packages for multiple architectures through their normal package repositories.
+* This cookbook does not attempt source builds or vendor repositories; it relies on distro-packaged libcgroup utilities only.
 
 ## Source URLs
 
-- Debian package index: <https://packages.debian.org/bookworm/libpam-cgroup>
-- Ubuntu package index: <https://packages.ubuntu.com/noble/admin/>
-- Amazon Linux 2023 cgroups guidance: <https://docs.aws.amazon.com/linux/al2023/ug/resource-limiting-raw-cgroups.html>
-- Amazon Linux 2023 cgroup v2 note: <https://docs.aws.amazon.com/linux/al2023/ug/cgroupv2.html>
+* Debian package index: <https://packages.debian.org/bookworm/libpam-cgroup>
+* Ubuntu package index: <https://packages.ubuntu.com/noble/admin/>
+* Amazon Linux 2023 cgroups guidance: <https://docs.aws.amazon.com/linux/al2023/ug/resource-limiting-raw-cgroups.html>
+* Amazon Linux 2023 cgroup v2 note: <https://docs.aws.amazon.com/linux/al2023/ug/cgroupv2.html>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Provides and configures cgroups
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 This cookbook now targets the resource-oriented API only and is validated against a narrow, explicit support matrix.
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'control_groups'
+
+run_list 'test::default'
+
+cookbook 'control_groups', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Manage control groups (cgroups) via chef!
 - Debian 12
 - Ubuntu 24.04
 
-See [`LIMITATIONS.md`](LIMITATIONS.md) for the researched support policy and unsupported platforms.
+See [`AGENTS.md`](AGENTS.md) for the researched support policy and unsupported platforms.
 
-Current unit verification passes on this repository. The Kitchen suites (`default`, `entry`, and `rule`) run on Debian 12 and Ubuntu 24.04 with `manage_runtime false` because Dokken/cgroup-v2 containers cannot start the legacy libcgroup mount workflow. See [`LIMITATIONS.md`](LIMITATIONS.md) for the runtime caveat.
+Current unit verification passes on this repository. The Kitchen suites (`default`, `entry`, and `rule`) run on Debian 12 and Ubuntu 24.04 with `manage_runtime false` because Dokken/cgroup-v2 containers cannot start the legacy libcgroup mount workflow. See [`AGENTS.md`](AGENTS.md) for the runtime caveat.
 
 ## Maintainers
 

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -49,7 +49,11 @@ suites:
     verifier: *default_verifier
   - name: entry
     run_list: *entry_run_list
+    provisioner:
+      named_run_list: entry
     verifier: *entry_verifier
   - name: rule
     run_list: *rule_run_list
+    provisioner:
+      named_run_list: rule
     verifier: *rule_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress